### PR TITLE
add support for cc and bcc

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,17 +11,17 @@
     "url": "git://github.com/sendgrid/nodemailer-sendgrid-transport.git"
   },
   "keywords": [
-    "SendGrid",
-    "Nodemailer"
+    "Nodemailer",
+    "SendGrid"
   ],
   "author": "SendGrid <community@sendgrid.com> (sendgrid.com)",
   "contributors": [
     "Eddie Zaneski <eddiezane@sendgrid.com",
     "Will Smidlein <ws@sendgrid.com>"
-   ],
+  ],
   "license": "MIT",
   "dependencies": {
-    "sendgrid": "^1.2.1"
+    "sendgrid": "^1.8.0"
   },
   "devDependencies": {
     "chai": "^1.9.1",

--- a/src/sendgrid-transport.js
+++ b/src/sendgrid-transport.js
@@ -22,7 +22,9 @@ SendGridTransport.prototype.send = function(mail, callback) {
   // fetch envelope data from the message object
   var addresses = mail.message.getAddresses();
   var from = [].concat(addresses.from || addresses.sender || addresses['reply-to'] || []).shift();
-  var to = [].concat(addresses.to || []).concat(addresses.cc || []).concat(addresses.bcc || []);
+  var to = [].concat(addresses.to || []);
+  var cc = [].concat(addresses.cc || []);
+  var bcc = [].concat(addresses.bcc || []);
 
   // populate from and fromname
   if (from) {
@@ -42,6 +44,15 @@ SendGridTransport.prototype.send = function(mail, callback) {
 
   email.toname = to.map(function(rcpt) {
     return rcpt.name || '';
+  });
+
+  // populate cc and bcc arrays
+  email.cc = cc.map(function(rcpt) {
+    return rcpt.address || '';
+  });
+
+  email.bcc = bcc.map(function(rcpt) {
+    return rcpt.address || '';
   });
 
   // a list for processing attachments


### PR DESCRIPTION
sendgrid/nodemailer-sendgrid-transport#8

It only sends cc and bcc `address` field and not `name` field as sendgrid client doesn't seem to support them

tested it with and it seems to work fine