### PR TITLE
ASM Group ID on emails

### DIFF
--- a/src/sendgrid-transport.js
+++ b/src/sendgrid-transport.js
@@ -112,9 +112,15 @@ SendGridTransport.prototype.send = function(mail, callback) {
 
     // if all parts are processed, send out the e-mail
     if (pos >= contents.length) {
+      var sendgridASMGroupID = null;
+      if (email.sendgridASMGroupID) {
+        sendgridASMGroupID = email.sendgridASMGroupID;
+        delete email.sendgridASMGroupID;
+      }
+
       var sendgridEmail = new _self.sendgrid.Email(email);
-      if (_self.options.asmGroupId) {
-        sendgridEmail.setASMGroupID(_self.options.asmGroupId);
+      if (sendgridASMGroupID) {
+        sendgridEmail.setASMGroupID(sendgridASMGroupID);
       }
 
       return _self.sendgrid.send(sendgridEmail, function(err, json) {

--- a/src/sendgrid-transport.js
+++ b/src/sendgrid-transport.js
@@ -112,7 +112,12 @@ SendGridTransport.prototype.send = function(mail, callback) {
 
     // if all parts are processed, send out the e-mail
     if (pos >= contents.length) {
-      return _self.sendgrid.send(email, function(err, json) {
+      var sendgridEmail = new _self.sendgrid.Email(email);
+      if (_self.options.asmGroupId) {
+        sendgridEmail.setASMGroupID(_self.options.asmGroupId);
+      }
+
+      return _self.sendgrid.send(sendgridEmail, function(err, json) {
         callback(err, json);
       });
     }


### PR DESCRIPTION
Adds the ability to set the ASM Group ID on emails.

So when sending the email:
transport.sendMail({
    from: 'test@test.com',
    to: 'test1@test.com',
    subject: 'test subject',
    html: 'test message',
    sendgridASMGroupID: 123
  }, callback);

Couldn't think of a better way to do this than putting it in the mail options, then deleting it within the transport.
#14
