### PR TITLE
Add support for passing options to the sendgrid module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ var options = {
 		api_key: 'SENDGRID_PASSWORD'
 	}
 }
-	
+
 var mailer = nodemailer.createTransport(sgTransport(options));
 ```
 
@@ -55,6 +55,26 @@ mailer.sendMail(email, function(err, res) {
 	}
 	console.log(res);
 });
+```
+
+### Options
+You can pass options, such as proxy settings, to the SendGrid module when creating an instance of the transport.
+
+```javascript
+var nodemailer = require('nodemailer');
+var sgTransport = require('nodemailer-sendgrid-transport');
+
+var options = {
+	auth: {
+		api_user: 'SENDGRID_USERNAME',
+		api_key: 'SENDGRID_PASSWORD'
+	},
+	options: {
+		proxy: 'http://localproxy:3128'
+	}
+}
+
+var mailer = nodemailer.createTransport(sgTransport(options));
 ```
 
 ## Deploying

--- a/src/sendgrid-transport.js
+++ b/src/sendgrid-transport.js
@@ -16,10 +16,10 @@ function SendGridTransport(options) {
 
   if (!this.options.auth.api_user) {
     // api key
-    this.sendgrid = SendGrid(this.options.auth.api_key);
+    this.sendgrid = SendGrid(this.options.auth.api_key, this.options.options);
   } else {
     // username + password
-    this.sendgrid = SendGrid(this.options.auth.api_user, this.options.auth.api_key);
+    this.sendgrid = SendGrid(this.options.auth.api_user, this.options.auth.api_key, this.options.options);
   }
 }
 


### PR DESCRIPTION
For the poor souls among us who can, in some environments, access web sites only through a proxy, or otherwise want to pass options to the sendgrid module.

Tested by successfully sending several e-mails using nodemailer-sendgrid-transport from my network environment featuring a mandatory proxy, with both the "proxy" and "agent" options, one at a time.

Signed-off-by: Lionel Debroux <lionel_debroux@yahoo.fr>