### PR TITLE
API KEY clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ var sgTransport = require('nodemailer-sendgrid-transport');
 // api key https://sendgrid.com/docs/Classroom/Send/api_keys.html
 var options = {
 	auth: {
-		api_key: 'SENDGRID_PASSWORD'
+		api_key: 'SENDGRID_APIKEY'
 	}
 }
 


### PR DESCRIPTION
When using a SendGrid API KEY, the api_user key and value cannot be used, rather only the api_key key and the value set as the SendGrid API KEY.