### PR TITLE
Support categories

### DIFF
--- a/src/sendgrid-transport.js
+++ b/src/sendgrid-transport.js
@@ -112,7 +112,16 @@ SendGridTransport.prototype.send = function(mail, callback) {
 
     // if all parts are processed, send out the e-mail
     if (pos >= contents.length) {
-      return _self.sendgrid.send(email, function(err, json) {
+
+      var sendgridEmail = new _self.sendgrid.Email(email);
+
+      if (email.categories && email.categories.length) {
+        email.categories.forEach(function(category) {
+          sendgridEmail.addCategory(category);
+        });
+      }
+
+      return _self.sendgrid.send(sendgridEmail, function(err, json) {
         callback(err, json);
       });
     }


### PR DESCRIPTION
This pull request adds support for categories. Test it by sending an email using this transport and specifying `categories` as an array of strings. You should see in the sendgrid dashboard that emails are being sent with your category/ies. 

I'm not entirely sure on the implementation and noticed that the test suite wasn't really setup for me to add a test for this. I'd really appreciate feedback that helps us get this merged :)