### PR TITLE
add support for categories

### DIFF
--- a/src/sendgrid-transport.js
+++ b/src/sendgrid-transport.js
@@ -26,8 +26,8 @@ function SendGridTransport(options) {
 // if in "name" <address@example.com> format, reformat to just address@example.com
 function trimReplyTo(a) {
     if (a.indexOf('<') >= 0 && a.indexOf('>') > 0) {
-        return a.substring(a.indexOf('<')+1, a.indexOf('>'));  
-    } 
+        return a.substring(a.indexOf('<')+1, a.indexOf('>'));
+    }
     return a;
 }
 
@@ -112,7 +112,20 @@ SendGridTransport.prototype.send = function(mail, callback) {
 
     // if all parts are processed, send out the e-mail
     if (pos >= contents.length) {
-      return _self.sendgrid.send(email, function(err, json) {
+      var sendgridEmail = new _self.sendgrid.Email(email);
+
+
+      if (email.categories) {
+        if(Array.isArray(email.categories) && email.categories.length) {
+          email.categories.forEach(function(category) {
+            sendgridEmail.addCategory(category);
+          });
+        } else if(typeof email.categories === 'string') {
+          sendgridEmail.addCategory(categories);
+        }
+      }
+
+      return _self.sendgrid.send(sendgridEmail, function(err, json) {
         callback(err, json);
       });
     }

--- a/src/sendgrid-transport.js
+++ b/src/sendgrid-transport.js
@@ -119,7 +119,7 @@ SendGridTransport.prototype.send = function(mail, callback) {
         if(Array.isArray(email.categories) && email.categories.length) {
           categories = email.categories;
         } else if(typeof email.categories === 'string') {
-          categories = email.categories.split(/\s*,\s*/));
+          categories = email.categories.split(/\s*,\s*/);
         }
 
         categories.forEach(function(category) {

--- a/src/sendgrid-transport.js
+++ b/src/sendgrid-transport.js
@@ -114,15 +114,17 @@ SendGridTransport.prototype.send = function(mail, callback) {
     if (pos >= contents.length) {
       var sendgridEmail = new _self.sendgrid.Email(email);
 
-
       if (email.categories) {
+        var categories = [];
         if(Array.isArray(email.categories) && email.categories.length) {
-          email.categories.forEach(function(category) {
-            sendgridEmail.addCategory(category);
-          });
+          categories = email.categories;
         } else if(typeof email.categories === 'string') {
-          sendgridEmail.addCategory(categories);
+          categories = email.categories.split(/\s*,\s*/));
         }
+
+        categories.forEach(function(category) {
+          sendgridEmail.addCategory(category);
+        });
       }
 
       return _self.sendgrid.send(sendgridEmail, function(err, json) {


### PR DESCRIPTION
This commit provides support for categories with option categories.

```js
var email = {
    to: ['joe@foo.com', 'mike@bar.com'],
    from: 'roger@tacos.com',
    subject: 'Hi there',
    text: 'Awesome sauce',
    html: '<b>Awesome sauce</b>',
    categories: 'category-a,category-b'
};
```
or
```js
var email = {
    to: ['joe@foo.com', 'mike@bar.com'],
    from: 'roger@tacos.com',
    subject: 'Hi there',
    text: 'Awesome sauce',
    html: '<b>Awesome sauce</b>',
    categories: ['category-a', 'category-b']
};
```